### PR TITLE
feat: 属性reverseを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,15 +23,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- 再生するアニメーションを逆再生に変更する属性`reverse`を追加
+
 ### Changed
 
 - 属性`visible-state`において複数の値を設定できるように変更
+- `playAnimation()`の引数を(`clip`, `loopCount`, `toState`, `onstart`, `onend`)から(`clip`, `options`)に変更
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+- 属性`visible-state`を指定しなかった場合エラーが発生する問題を修正
 
 ## [1.1.0] - 2022-02-07
 

--- a/index.html
+++ b/index.html
@@ -26,6 +26,8 @@
           position="-0.2m 0m 0m"
           to-state="pushin"
           visible-state="pushout pushin"
+          onstart="console.log('start push in')"
+          onend="console.log('end push in')"
         ></button>
         <button
           slot="hotspot-b"
@@ -33,11 +35,28 @@
           position=" 0.2m 0m 0m"
           to-state="pushout"
           visible-state="pushin"
+          reverse
+          onstart="console.log('start pull out')"
+          onend="console.log('end pull out')"
+        ></button>
+        <button
+          slot="hotspot-c"
+          position="0.2m 0.5m 0m"
+          onclick="play()"
         ></button>
       </figni-viewer>
     </div>
     <script>
       const view = document.querySelector('figni-viewer')
+      function play() {
+        view.playAnimation('Push_in', {
+          loopCount: 2,
+          toState: 'pushin',
+          reverse: true,
+          onStart: () => console.log('start push in'),
+          onEnd: () => console.log('end push in'),
+        })
+      }
     </script>
     <style>
       #view {


### PR DESCRIPTION
# Description

アニメーションを再生する際に逆再生に変更する属性`reverse`を追加しました。
また、それに伴い関数`playAnimation()`の引数を大幅に変更しました。詳細はドキュメント記載。

## Change Log

### Added

- 再生するアニメーションを逆再生に変更する属性`reverse`を追加

### Changed

- 属性`visible-state`において複数の値を設定できるように変更
- `playAnimation()`の引数を(`clip`, `loopCount`, `toState`, `onstart`, `onend`)から(`clip`, `options`)に変更

### Fixed

- 属性`visible-state`を指定しなかった場合エラーが発生する問題を修正
