### PR TITLE
feat: normalを指定しないHotspotは常に見えるように変更

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - 属性`visible-state`において複数の値を設定できるように変更
 - `playAnimation()`の引数を(`clip`, `loopCount`, `toState`, `onstart`, `onend`)から(`clip`, `options`)に変更
+- *hotspot*において属性`normal`を指定しなかった場合、常に見えるように変更
 
 ### Deprecated
 

--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
           clip="Push_in"
           position="-0.2m 0m 0m"
           to-state="pushin"
+          normal="0m 1m 0m"
           visible-state="pushout pushin"
           onstart="console.log('start push in')"
           onend="console.log('end push in')"

--- a/src/index.js
+++ b/src/index.js
@@ -362,10 +362,12 @@ export class FigniViewerElement extends ModelViewerElement {
       'position',
       position || FigniViewerElement.#DEFAULT_HOTSPOT_POSITION
     )
-    hotspot.setAttribute(
-      'normal',
-      normal || FigniViewerElement.#DEFAULT_HOTSPOT_NORMAL
-    )
+    if (normal) {
+      hotspot.setAttribute(
+        'normal',
+        normal || FigniViewerElement.#DEFAULT_HOTSPOT_NORMAL
+      )
+    }
     hotspot.setAttribute('slot', `hotspot-${name}`)
     if (options) {
       if (options.anime) {
@@ -412,10 +414,16 @@ export class FigniViewerElement extends ModelViewerElement {
       throw new ReferenceError(`Hotspot ${name} not found`)
     }
     if (position) {
-      hotspot.setAttribute('position', position)
+      hotspot.setAttribute(
+        'position',
+        position || FigniViewerElement.#DEFAULT_HOTSPOT_POSITION
+      )
     }
     if (normal) {
-      hotspot.setAttribute('normal', normal)
+      hotspot.setAttribute(
+        'normal',
+        normal || FigniViewerElement.#DEFAULT_HOTSPOT_NORMAL
+      )
     }
     if (options) {
       if (options.anime) {
@@ -481,16 +489,19 @@ export class FigniViewerElement extends ModelViewerElement {
       hotspot.getAttribute('position') ||
         FigniViewerElement.#DEFAULT_HOTSPOT_POSITION
     )
-    hotspot.setAttribute(
-      'normal',
-      hotspot.getAttribute('normal') ||
-        FigniViewerElement.#DEFAULT_HOTSPOT_NORMAL
-    )
-    this.updateHotspot({
-      name: hotspot.getAttribute('slot'),
-      position: hotspot.getAttribute('position'),
-      normal: hotspot.getAttribute('normal'),
-    })
+    if (hotspot.getAttribute('normal')) {
+      this.updateHotspot({
+        name: hotspot.getAttribute('slot'),
+        position: hotspot.getAttribute('position'),
+        normal: hotspot.getAttribute('normal'),
+      })
+    } else {
+      hotspot.classList.add('figni-viewer-hotspot-no-normal')
+      this.updateHotspot({
+        name: hotspot.getAttribute('slot'),
+        position: hotspot.getAttribute('position'),
+      })
+    }
 
     const name = hotspot.getAttribute('slot')
     const isAnime =

--- a/src/style.scss
+++ b/src/style.scss
@@ -68,8 +68,12 @@ figni-viewer * {
 }
 
 .figni-viewer-hotspot-hide {
-  opacity: var(--min-hotspot-opacity);
+  opacity: 0;
   pointer-events: none;
+}
+
+.figni-viewer-hotspot-no-normal {
+  --min-hotspot-opacity: 1;
 }
 
 .figni-viewer-panel {


### PR DESCRIPTION
# Description

*hotspot*において、属性`normal`を指定しなかった場合、最低不透明度が1になるように変更しました。
これによりキャプションを消す処理や*state*の変化、アニメーションの再生中以外は常に見えるようにすることができます。

## Change Log

### Changed

- *hotspot*において属性`normal`を指定しなかった場合、常に見えるように変更
