### PR TITLE
feat: Hotspotを操作する関数のreverseへの対応

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,13 +23,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- `addHotspot()`の引数に`reverse`を追加
+- `editHotspot()`の引数に`reverse`を追加
+
 ### Changed
+
+- `addHotspot()`の引数`onstart`および`onend`をそれぞれ`onStart`、`onEnd`に変更
+- `editHotspot()`の引数`onstart`および`onend`をそれぞれ`onStart`、`onEnd`に変更
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+- `addHotspot()`が正しく動作しない問題を修正
 
 ## [1.2.0] - 2022-02-10
 

--- a/index.html
+++ b/index.html
@@ -18,44 +18,33 @@
         item-id="jX8I8IVG"
         token="ZRZYCb22MFWG7ha4"
         orbit="40deg 75deg 150%"
-        state="pushout"
       >
-        <button
-          slot="hotspot-a"
-          clip="Push_in"
-          position="-0.2m 0m 0m"
-          to-state="pushin"
-          normal="0m 1m 0m"
-          visible-state="pushout pushin"
-          onstart="console.log('start push in')"
-          onend="console.log('end push in')"
-        ></button>
-        <button
-          slot="hotspot-b"
-          clip="Pull_out"
-          position=" 0.2m 0m 0m"
-          to-state="pushout"
-          visible-state="pushin"
-          reverse
-          onstart="console.log('start pull out')"
-          onend="console.log('end pull out')"
-        ></button>
-        <button
-          slot="hotspot-c"
-          position="0.2m 0.5m 0m"
-          onclick="play()"
-        ></button>
       </figni-viewer>
+      <button onclick="Add()">Add</button>
+      <button onclick="Edit()">Edit</button>
     </div>
     <script>
       const view = document.querySelector('figni-viewer')
-      function play() {
-        view.playAnimation('Push_in', {
-          loopCount: 2,
-          toState: 'pushin',
-          reverse: true,
-          onStart: () => console.log('start push in'),
-          onEnd: () => console.log('end push in'),
+      function Add() {
+        view.addHotspot('sample', '-0.5m 0.5m 0m', null, {
+          anime: {
+            clip: 'Push_in',
+            loopCount: 1,
+            reverse: true,
+            onStart: () => {
+              console.log('start')
+            },
+            onEnd: () => {
+              console.log('end')
+            },
+          },
+        })
+      }
+      function Edit() {
+        view.editHotspot('sample', '0.5m 0.5m 0m', null, {
+          anime: {
+            reverse: false,
+          },
         })
       }
     </script>

--- a/src/index.js
+++ b/src/index.js
@@ -349,7 +349,7 @@ export class FigniViewerElement extends ModelViewerElement {
     URL.revokeObjectURL(url)
   }
 
-  addHotspot(name, position = null, normal = null, options = null) {
+  async addHotspot(name, position = null, normal = null, options = null) {
     if (!name) {
       throw new SyntaxError('name is required')
     }
@@ -377,14 +377,17 @@ export class FigniViewerElement extends ModelViewerElement {
         if (options.anime.loopCount) {
           hotspot.setAttribute('loopCount', options.anime.loopCount)
         }
-        if (options.anime.onstart) {
+        if (options.anime.reverse === true) {
+          hotspot.setAttribute('reverse', '')
+        }
+        if (options.anime.onStart) {
           hotspot.setAttribute(
             'onstart',
-            `(${options.anime.onstart.toString()})()`
+            `(${options.anime.onStart.toString()})()`
           )
         }
-        if (options.anime.onend) {
-          hotspot.setAttribute('onend', `(${options.anime.onend.toString()})()`)
+        if (options.anime.onEnd) {
+          hotspot.setAttribute('onend', `(${options.anime.onEnd.toString()})()`)
         }
       }
       if (options.closeup) {
@@ -403,9 +406,13 @@ export class FigniViewerElement extends ModelViewerElement {
       }
     }
     this.appendChild(hotspot)
+
+    await this.updateComplete
+    this.#modifyHotspot(hotspot)
+    this.updateState(this.state)
   }
 
-  editHotspot(name, position = null, normal = null, options = null) {
+  async editHotspot(name, position = null, normal = null, options = null) {
     if (!name) {
       throw new SyntaxError('name is required')
     }
@@ -433,14 +440,19 @@ export class FigniViewerElement extends ModelViewerElement {
         if (options.anime.loopCount) {
           hotspot.setAttribute('loopCount', options.anime.loopCount)
         }
-        if (options.anime.onstart) {
+        if (options.anime.reverse === true) {
+          hotspot.setAttribute('reverse', '')
+        } else if (options.anime.reverse === false) {
+          hotspot.removeAttribute('reverse')
+        }
+        if (options.anime.onStart) {
           hotspot.setAttribute(
             'onstart',
-            `(${options.anime.onstart.toString()})()`
+            `(${options.anime.onStart.toString()})()`
           )
         }
-        if (options.anime.onend) {
-          hotspot.setAttribute('onend', `(${options.anime.onend.toString()})()`)
+        if (options.anime.onEnd) {
+          hotspot.setAttribute('onend', `(${options.anime.onEnd.toString()})()`)
         }
       }
       if (options.closeup) {
@@ -458,6 +470,8 @@ export class FigniViewerElement extends ModelViewerElement {
         hotspot.setAttribute('to-state', options.toState)
       }
     }
+
+    await this.updateComplete
     this.#modifyHotspot(hotspot)
     this.updateState(this.state)
   }


### PR DESCRIPTION
# Description

関数addHotspotおよびeditHotspotに属性reverseへの対応を行いました。
それにともないいくつか修正も行っています。

## Change Log

### Added

- `addHotspot()`の引数に`reverse`を追加
- `editHotspot()`の引数に`reverse`を追加

_If you have any additional features or styles, please write them here._

### Changed

- `addHotspot()`の引数`onstart`および`onend`をそれぞれ`onStart`、`onEnd`に変更
- `editHotspot()`の引数`onstart`および`onend`をそれぞれ`onStart`、`onEnd`に変更

### Fixed

- `addHotspot()`が正しく動作しない問題を修正
