### PR TITLE
feat: キャプションの表示非表示を切り替えるボタンを制御できるようにする

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - `addHotspot()`の引数`onstart`および`onend`をそれぞれ`onStart`、`onEnd`に変更
 - `editHotspot()`の引数`onstart`および`onend`をそれぞれ`onStart`、`onEnd`に変更
+- キャプションの表示非表示を切り替えるボタンを属性`toggle-caption`の有無で制御できるように変更
 
 ### Deprecated
 

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ const VIEW_THRESHOLD = 0.7
 export class FigniViewerElement extends ModelViewerElement {
   static #FIGNI_OBSERBED_ATTRIBUTES = {
     MODEL: ['item-id', 'token', 'model-tag'],
-    TOOL: ['screenshot'],
+    TOOL: ['screenshot', 'toggle-caption'],
   }
 
   static #DEFAULT_CAMERA_TARGET = 'auto auto auto'
@@ -160,10 +160,6 @@ export class FigniViewerElement extends ModelViewerElement {
       this.#modifyHotspot(hotspot)
     })
 
-    if (this.#hotspots.length > 0) {
-      this.#enableToggleVisibleHotspotButton()
-    }
-
     this.#requestModel()
     this.setCameraTarget(this.#initCameraTarget)
     this.setCameraOrbit(this.#initCameraOrbit)
@@ -177,9 +173,6 @@ export class FigniViewerElement extends ModelViewerElement {
           for (const node of mutation.addedNodes) {
             if (typeof node == 'element') {
               if (/^hotspot/.test(node.getAttribute('slot'))) {
-                if (this.#hotspots.length == 0) {
-                  this.#enableToggleVisibleHotspotButton()
-                }
                 this.#hotspots.push(node)
                 this.#modifyHotspot(node)
                 this.updateState(this.state)
@@ -256,6 +249,14 @@ export class FigniViewerElement extends ModelViewerElement {
               this.#enableDownloadScreenshotButton()
             } else {
               this.#disableDownloadScreenshotButton()
+            }
+            break
+          }
+          case 'toggle-caption': {
+            if (newValue == '') {
+              this.#enableToggleVisibleHotspotButton()
+            } else {
+              this.#enableToggleVisibleHotspotButton()
             }
             break
           }


### PR DESCRIPTION
# Description

キャプションの表示非表示を切り替えるボタンをデフォルトでは出現しないようにして、属性`toggle-caption`をつけた場合のみにでるようにした。

## Change Log

### Changed

- キャプションの表示非表示を切り替えるボタンを属性`toggle-caption`の有無で制御できるように変更
