### PR TITLE
fix: CustomElementの定義に関するエラーの修正

### DIFF
--- a/src/figni-viewer.js
+++ b/src/figni-viewer.js
@@ -106,22 +106,25 @@ export default class FigniViewerElement extends HTMLElement {
 
   constructor() {
     super()
-
-    // Figni Viewer Base
-    this.#figniViewerBase = document.createElement('figni-viewer-base')
-    this.#figniViewerBase.style.flex = '1'
-    this.#figniViewerBase.style.height = '100%'
-    this.appendChild(this.#figniViewerBase)
-
-    // Figni Help Panel
-    this.#helpPanelBase = document.createElement('div')
-    this.#helpPanelBase.style.width = '0px'
-    this.appendChild(this.#helpPanelBase)
-
     this.#completedInitialModelLoad = false
   }
 
   async connectedCallback() {
+    // Figni Viewer Base
+    if (!this.#figniViewerBase) {
+      this.#figniViewerBase = document.createElement('figni-viewer-base')
+      this.#figniViewerBase.style.flex = '1'
+      this.#figniViewerBase.style.height = '100%'
+      this.appendChild(this.#figniViewerBase)
+    }
+
+    // Figni Help Panel
+    if (!this.#helpPanelBase) {
+      this.#helpPanelBase = document.createElement('div')
+      this.#helpPanelBase.style.width = '0px'
+      this.appendChild(this.#helpPanelBase)
+    }
+
     // Hotspot
     this.querySelectorAll('[slot^="hotspot"]').forEach((hotspot) => {
       this.#hotspots.push(this.#figniViewerBase.appendChild(hotspot))


### PR DESCRIPTION
# Description

Custom Element の宣言時にconstructorで属性の追加/編集や要素の追加を行ってはいけないというルールに則るように修正しました。
詳細は同様のエラーに見舞われた人のstackoverflowをご覧ください。
(https://stackoverflow.com/questions/43836886/failed-to-construct-customelement-error-when-javascript-file-is-placed-in-head)

## Change Log

### Fixed

- 初期化時に発生することがあるエラーを修正