### PR TITLE
fix: WebXR起動時のARボタンを削除

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - 使い方を紹介しているヘルプページを追加
+- WebXR の起動をサポート
 
 ### Changed
 

--- a/src/figni-viewer-base.js
+++ b/src/figni-viewer-base.js
@@ -222,7 +222,6 @@ export default class FigniViewerBaseElement extends ModelViewerElement {
     this.loading = 'lazy'
     this.cameraControls = true
     this.ar = true
-    // ! 一時的にWebXRを起動しないようにします
     this.arModes = 'webxr scene-viewer quick-look'
     this.arScale = 'fixed'
     this.arPlacement = 'floor'

--- a/src/figni-viewer-base.js
+++ b/src/figni-viewer-base.js
@@ -223,7 +223,7 @@ export default class FigniViewerBaseElement extends ModelViewerElement {
     this.cameraControls = true
     this.ar = true
     // ! 一時的にWebXRを起動しないようにします
-    this.arModes = 'scene-viewer quick-look'
+    this.arModes = 'webxr scene-viewer quick-look'
     this.arScale = 'fixed'
     this.arPlacement = 'floor'
     this.shadowIntensity = 1

--- a/src/figni-viewer.js
+++ b/src/figni-viewer.js
@@ -982,6 +982,7 @@ export default class FigniViewerElement extends HTMLElement {
       this.#arButton = document.createElement('span')
       this.#arButton.innerHTML = `${SVG_AR_BUTTON}<span>${this.ABTEST.AR_BUTTON_TEST}</span>`
       this.#arButton.classList.add('figni-viewer-ar-button')
+      alert(this.#figniViewerBase.canActivateAR)
       this.#arButton.addEventListener('click', () => {
         if (this.#figniViewerBase.canActivateAR) {
           this.#figniViewerBase.activateARMode()

--- a/src/figni-viewer.js
+++ b/src/figni-viewer.js
@@ -982,11 +982,15 @@ export default class FigniViewerElement extends HTMLElement {
       this.#arButton = document.createElement('span')
       this.#arButton.innerHTML = `${SVG_AR_BUTTON}<span>${this.ABTEST.AR_BUTTON_TEST}</span>`
       this.#arButton.classList.add('figni-viewer-ar-button')
-      alert(this.#figniViewerBase.canActivateAR)
-      this.#arButton.addEventListener('click', () => {
+      this.#figniViewerBase.addEventListener('load', (e) => {
         if (this.#figniViewerBase.canActivateAR) {
-          this.#figniViewerBase.activateARMode()
+          this.#arButton.setAttribute('slot', 'ar-button')
         } else {
+          this.#arButton.removeAttribute('slot')
+        }
+      })
+      this.#arButton.addEventListener('click', () => {
+        if (!this.#figniViewerBase.canActivateAR) {
           this.#showQRCodePanel()
         }
       })

--- a/src/figni-viewer.js
+++ b/src/figni-viewer.js
@@ -982,7 +982,7 @@ export default class FigniViewerElement extends HTMLElement {
       this.#arButton = document.createElement('span')
       this.#arButton.innerHTML = `${SVG_AR_BUTTON}<span>${this.ABTEST.AR_BUTTON_TEST}</span>`
       this.#arButton.classList.add('figni-viewer-ar-button')
-      this.#figniViewerBase.addEventListener('load', (e) => {
+      this.#figniViewerBase.addEventListener('load', () => {
         if (this.#figniViewerBase.canActivateAR) {
           this.#arButton.setAttribute('slot', 'ar-button')
         } else {


### PR DESCRIPTION
# Description

WebXR起動時にHTML要素であるARボタンが表示されていた問題を修正しました。それに伴い一時停止していたWebXRのサポートを再開しました。

_Please describe what you changed._

## Change Log

### Added

- WebXRの起動をサポート

