### PR TITLE
feat: カメラ位置をリセットするボタンの変更

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- キャプションを押してカメラの位置が変更されたときに、キャプションを戻るボタンとして使用できるように変更
+
 ### Deprecated
 
 ### Removed
@@ -41,7 +43,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- *panel*のサイズを調整
+- パネルのサイズを調整
 - CSS で指定したカスタム色が影響を及ぼす範囲を拡大
 - カメラの位置を初期位置に戻すボタンのスタイルを変更
 - エラー画面のスタイルを変更
@@ -54,7 +56,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- *panel*をクリックしても*hotspot*をクリックしたときと同じ動作をしてしまう問題を修正
+- パネルをクリックしてもキャプションをクリックしたときと同じ動作をしてしまう問題を修正
 
 ## [1.4.3] - 2022-04-22
 
@@ -86,7 +88,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- *hotspot*に強調アニメーションを追加
+- キャプションに強調アニメーションを追加
 - タッチ(クリック)している位置を強調するカーソルを追加
 
 ### Changed
@@ -127,7 +129,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - 属性`visible-state`において複数の値を設定できるように変更
 - `playAnimation()`の引数を(`clip`, `loopCount`, `toState`, `onstart`, `onend`)から(`clip`, `options`)に変更
-- *hotspot*において属性`normal`を指定しなかった場合、常に見えるように変更
+- キャプションにおいて属性`normal`を指定しなかった場合、常に見えるように変更
 
 ### Fixed
 
@@ -159,7 +161,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- *hotspot*に関して、完全に可視化されるまでクリックできない問題を修正
+- キャプションに関して、完全に可視化されるまでクリックできない問題を修正
 
 ## [1.0.2] - 2022-01-25
 
@@ -203,7 +205,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- 消えた*hotspot*にクリック判定が残っていた問題を修正
+- 消えたキャプションにクリック判定が残っていた問題を修正
 
 ## [0.0.33] - 2021-12-28
 
@@ -245,7 +247,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - `onstart`, `onend`が正しく動作しない問題を修正
-- *hotspot*の表示非表示が正しく切り替わらない問題を修正
+- キャプションの表示非表示が正しく切り替わらない問題を修正
 
 ## [0.0.29] - 2021-12-13
 
@@ -265,18 +267,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - `orbit`の指定が正しく反映されていない問題を修正
-- *panel*のデザインを修正
-- `addHotspot()`で名前が重複した*hotspot*を追加した場合にエラーを起こす問題を修正
+- パネルのデザインを修正
+- `addHotspot()`で名前が重複したキャプションを追加した場合にエラーを起こす問題を修正
 
 ## [0.0.26] - 2021-12-06
 
 ### Added
 
-- *panel*の位置を指定することができる属性`place`を追加
+- パネルの位置を指定することができる属性`place`を追加
 
 ### Fixed
 
-- *panel*のデザインを修正
+- パネルのデザインを修正
 
 ## [0.0.25] - 2021-12-06
 
@@ -289,7 +291,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - `model-tag`を利用した 3D モデルの読み込みが正しく行われていない問題を修正
-- `visible`の設定されていない*hotspot*の表示非表示が正しく行われていない問題を修正
+- `visible`の設定されていないキャプションの表示非表示が正しく行われていない問題を修正
 
 ## [0.0.23] - 2021-12-01
 
@@ -299,13 +301,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- *hotspot*が存在しない場合*hotspot*の表示非表示を切り替えるボタンが出ないように修正
+- キャプションが存在しない場合キャプションの表示非表示を切り替えるボタンが出ないように修正
 
 ## [0.0.22] - 2021-12-01
 
 ### Fixed
 
-- *hotspot*の機能およびスタイルが適切に適用されない場合がある問題を修正
+- キャプションの機能およびスタイルが適切に適用されない場合がある問題を修正
 
 ## [0.0.21] - 2021-11-30
 
@@ -328,16 +330,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- *hotspot*の表示非表示を切り替えるボタンを追加
-- *hotspot*の表示非表示を切り替える`toggleVisibleHotspot()`関数を追加
+- キャプションの表示非表示を切り替えるボタンを追加
+- キャプションの表示非表示を切り替える`toggleVisibleHotspot()`関数を追加
 
 ## [0.0.18] - 2021-11-24
 
 ### Added
 
-- *hotspot*を追加する`addHotspot()`関数を追加
-- *hotspot*の位置や機能を編集する`editHotspot()`関数を追加
-- *hotspot*を削除する`removeHotspot()`関数を追加
+- キャプションを追加する`addHotspot()`関数を追加
+- キャプションの位置や機能を編集する`editHotspot()`関数を追加
+- キャプションを削除する`removeHotspot()`関数を追加
 
 ### Fixed
 
@@ -349,8 +351,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- *hotspot*のスタイルを上書きできるように変更
-- *panel*のスタイルを上書きできるように変更
+- キャプションのスタイルを上書きできるように変更
+- パネルのスタイルを上書きできるように変更
 - カメラを初期位置に戻すボタンのスタイルを上書きできるように変更
 - スクリーンショットボタンのスタイルを上書きできるように変更
 
@@ -362,8 +364,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- *hotspot*の表示非表示を変化させる`to-state`属性を追加
-- *hotspot*の表示非表示を決定する`visible`属性を追加
+- キャプションの表示非表示を変化させる`to-state`属性を追加
+- キャプションの表示非表示を決定する`visible`属性を追加
 
 [unreleased]: https://github.com/cynack/figni-viewer/compare/v1.5.0...HEAD
 [1.5.0]: https://github.com/cynack/figni-viewer/compare/v1.4.5...v1.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## Future Plans
-
-### Add
-
-### Change
-
-### Deprecate
-
-### Remove
-
-### Fix
-
 ## [Unreleased]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Deprecated
 
+- パネルの位置を`center middle`にすることを非推奨に変更
+
 ### Removed
 
 ### Fixed

--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
           orbit="45deg 90deg 0.5m"
         >
           5
-          <div slot="panel" place="right bottom">
+          <div slot="panel" place="right middle">
             <img src="https://admin.figni.io//sample/suitcase/caption_2.png" />
             <h4>タイトル</h4>
             <p>文章</p>

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
           position="-0.5m 0m 0.5m"
           target="0.1m 0.1m 0m"
           orbit="-45deg 90deg 0.5m"
+          normal="0 1 0"
           >1</span
         >
         <!-- positionがない場合は"0 0 0"を指定した場合と同義、targetがない場合はpositionの値が使用される -->

--- a/index.html
+++ b/index.html
@@ -27,7 +27,12 @@
           >1</span
         >
         <!-- positionがない場合は"0 0 0"を指定した場合と同義、targetがない場合はpositionの値が使用される -->
-        <span slot="hotspot-test2" orbit="-45deg 90deg 0.5m">2</span>
+        <span slot="hotspot-test2" orbit="-45deg 90deg 0.5m"
+          >2<img
+            src="https://admin.figni.io//sample/suitcase/caption_2.png"
+            width="10px"
+            height="10px"
+        /></span>
         <span
           slot="hotspot-test3"
           position="-0.4m 0m 0.5m"

--- a/src/figni-viewer.js
+++ b/src/figni-viewer.js
@@ -164,8 +164,23 @@ export default class FigniViewerElement extends HTMLElement {
       this.#figniViewerBase.addEventListener('finished', () => {
         this.dispatchEvent(new CustomEvent('animation-finished'))
       })
+      this.#figniViewerBase.addEventListener('camera-change', (e) => {
+        this.dispatchEvent(
+          new CustomEvent('camera-change', { detail: e.detail })
+        )
+      })
       this.appendChild(this.#figniViewerBase)
     }
+
+    this.addEventListener('camera-change', (e) => {
+      if (this.#tempHidedHotspot) {
+        if (!this.#clickableHotspot(this.#tempHidedHotspot.target)) {
+          this.#showInitCameraButton()
+        } else {
+          this.#hideInitCameraButton()
+        }
+      }
+    })
 
     // AB TEST
     if (Math.random() > 0.5) {
@@ -981,7 +996,20 @@ export default class FigniViewerElement extends HTMLElement {
   }
 
   #clickableHotspot(hotspot) {
-    return window.getComputedStyle(hotspot).opacity > 0.5
+    const isClickableOpacity = window.getComputedStyle(hotspot).opacity > 0.5
+    const isClickablePosition = (function (_this) {
+      const viewerRect = _this.#figniViewerBase.getBoundingClientRect()
+      const hotspotRect = hotspot.getBoundingClientRect()
+      const hotspotRectSize = hotspotRect.width * hotspotRect.height
+      const viewHotspotRectSize =
+        (Math.min(hotspotRect.right, viewerRect.right) -
+          Math.max(hotspotRect.left, viewerRect.left)) *
+        (Math.min(hotspotRect.bottom, viewerRect.bottom) -
+          Math.max(hotspotRect.top, viewerRect.top))
+      const ratio = viewHotspotRectSize / hotspotRectSize
+      return ratio > 0.5
+    })(this)
+    return isClickableOpacity && isClickablePosition
   }
 
   #modifyPanel(panel) {

--- a/src/figni-viewer.js
+++ b/src/figni-viewer.js
@@ -961,8 +961,8 @@ export default class FigniViewerElement extends HTMLElement {
               }
               panel.classList.toggle('figni-viewer-panel-hide')
             })
-            this.#closeAllPanels(Array.from(panels))
           }
+          this.#closeAllPanels(Array.from(panels))
         }
       }
     })

--- a/src/figni-viewer.js
+++ b/src/figni-viewer.js
@@ -77,9 +77,13 @@ export default class FigniViewerElement extends HTMLElement {
   #hotspots = []
   #panels = []
 
-  // private field
   #completedInitialModelLoad = false
   #visibleAllHotspots = true
+  #currentCloseupedHotspot = {
+    name: '',
+    target: null,
+    text: '',
+  }
 
   #ABTEST = {
     AR_BUTTON_TEST: '実物大で見る',
@@ -263,6 +267,7 @@ export default class FigniViewerElement extends HTMLElement {
   resetCameraTargetAndOrbit() {
     this.setCameraTarget(this.target)
     this.setCameraOrbit(this.orbit)
+    this.#showTemporaryHidedHotspot()
     this.#hideInitCameraButton()
   }
 
@@ -876,6 +881,7 @@ export default class FigniViewerElement extends HTMLElement {
             } else {
               this.setCameraTarget(target)
               this.setCameraOrbit(orbit)
+              this.#temporaryHideHotspot(name, hotspot)
             }
           }
         }
@@ -1738,6 +1744,54 @@ export default class FigniViewerElement extends HTMLElement {
       animation.classList.add('figni-viewer-tips-panel-animation')
       this.#tipsPanel.appendChild(animation)
       this.#figniViewerBase.appendChild(this.#tipsPanel)
+    }
+  }
+
+  #closeHotspotButton
+  #tempHidedHotspot = null
+  #temporaryHideHotspot(name, hotspot) {
+    if (this.#tempHidedHotspot && this.#tempHidedHotspot.name !== name) {
+      this.#showTemporaryHidedHotspot()
+    }
+
+    // 一時保存
+    this.#tempHidedHotspot = {
+      name: name,
+      target: hotspot,
+      text: [],
+    }
+
+    hotspot.childNodes.forEach((child) => {
+      if (child.nodeType === Node.TEXT_NODE) {
+        this.#tempHidedHotspot.text.push(child.nodeValue)
+        child.nodeValue = ''
+      } else if (child.nodeType === Node.ELEMENT_NODE) {
+        if (!(child.getAttribute('slot') ?? '').match(/^panel/)) {
+          child.style.display = 'none'
+        }
+      }
+    })
+
+    if (!this.#closeHotspotButton) {
+      this.#closeHotspotButton = document.createElement('div')
+      this.#closeHotspotButton.classList.add(
+        'figni-viewer-hotspot-close-button'
+      )
+      this.#closeHotspotButton.innerHTML = SVG_CLOSE_ICON
+    }
+    hotspot.appendChild(this.#closeHotspotButton)
+  }
+  #showTemporaryHidedHotspot() {
+    if (this.#tempHidedHotspot) {
+      this.#tempHidedHotspot.target.removeChild(this.#closeHotspotButton)
+      this.#tempHidedHotspot.target.childNodes.forEach((child) => {
+        if (child.nodeType === Node.TEXT_NODE) {
+          child.nodeValue = this.#tempHidedHotspot.text.shift()
+        } else if (child.nodeType === Node.ELEMENT_NODE) {
+          child.style.display = ''
+        }
+      })
+      this.#tempHidedHotspot = null
     }
   }
 }

--- a/src/figni-viewer.js
+++ b/src/figni-viewer.js
@@ -964,7 +964,9 @@ export default class FigniViewerElement extends HTMLElement {
               panel.classList.add('figni-viewer-panel-hide')
             }
           })
-          this.#closeAllPanels(Array.from(panels))
+          if (isCloseup || panels.length > 0) {
+            this.#closeAllPanels(Array.from(panels))
+          }
         }
       }
     })

--- a/src/figni-viewer.js
+++ b/src/figni-viewer.js
@@ -906,8 +906,8 @@ export default class FigniViewerElement extends HTMLElement {
     hotspot.addEventListener('click', (e) => {
       if (this.#clickableHotspot(hotspot)) {
         if (e.target == hotspot) {
-          if (panels.length > 0) {
-            panels.forEach((panel) => {
+          panels.forEach((panel) => {
+            if (panel.classList.contains('figni-viewer-panel-hide')) {
               const baseWidth = Number(
                 window
                   .getComputedStyle(this.#figniViewerBase)
@@ -959,9 +959,11 @@ export default class FigniViewerElement extends HTMLElement {
                   (baseHeight - hotspotHeight) / 2
                 }px - 2.25rem)`
               }
-              panel.classList.toggle('figni-viewer-panel-hide')
-            })
-          }
+              panel.classList.remove('figni-viewer-panel-hide')
+            } else {
+              panel.classList.add('figni-viewer-panel-hide')
+            }
+          })
           this.#closeAllPanels(Array.from(panels))
         }
       }

--- a/src/figni-viewer.js
+++ b/src/figni-viewer.js
@@ -1038,6 +1038,9 @@ export default class FigniViewerElement extends HTMLElement {
     } else if (horizontal == 'left' && vertical == 'middle') {
       panel.classList.add('figni-viewer-panel-place-left-middle')
     } else if (horizontal == 'center' && vertical == 'middle') {
+      console.warn(
+        '警告：パネルをキャプションの中心に配置することは推奨されていません'
+      )
       panel.classList.add('figni-viewer-panel-place-center-middle')
     } else if (horizontal == 'right' && vertical == 'middle') {
       panel.classList.add('figni-viewer-panel-place-right-middle')

--- a/src/figni-viewer.js
+++ b/src/figni-viewer.js
@@ -247,6 +247,10 @@ export default class FigniViewerElement extends HTMLElement {
     if (this.#figniViewerBase.cameraTarget !== target) {
       this.#showInitCameraButton()
     }
+    this.#setCameraTarget(target)
+  }
+
+  #setCameraTarget(target) {
     this.#figniViewerBase.setCameraTarget(target)
   }
 
@@ -258,6 +262,10 @@ export default class FigniViewerElement extends HTMLElement {
     if (this.#figniViewerBase.cameraOrbit !== orbit) {
       this.#showInitCameraButton()
     }
+    this.#setCameraOrbit(orbit)
+  }
+
+  #setCameraOrbit(orbit) {
     this.#figniViewerBase.setCameraOrbit(orbit)
   }
 
@@ -879,8 +887,8 @@ export default class FigniViewerElement extends HTMLElement {
             ) {
               this.resetCameraTargetAndOrbit()
             } else {
-              this.setCameraTarget(target)
-              this.setCameraOrbit(orbit)
+              this.#setCameraTarget(target)
+              this.#setCameraOrbit(orbit)
               this.#temporaryHideHotspot(name, hotspot)
             }
           }

--- a/src/style.scss
+++ b/src/style.scss
@@ -97,6 +97,10 @@ figni-viewer * {
   --min-hotspot-opacity: 1;
 }
 
+.figni-viewer-hotspot-close-button {
+  margin: 0.1rem 0;
+}
+
 .figni-viewer-panel {
   width: 240px;
   background-color: white;


### PR DESCRIPTION
# Description

キャプションを押してカメラ位置が変更された場合、押したキャプションが✕ボタンに変化するようにし、✕ボタンが表示から消えた場合のみ画面左上のカメラ位置リセットボタンを表示するように変更しました。

## Change Log

### Changed

- キャプションを押してカメラの位置が変更されたときに、キャプションを戻るボタンとして使用できるように変更
