### PR TITLE
fix: modifyHotspotの適用が重複してしまう問題を修正

### DIFF
--- a/src/figni-viewer.js
+++ b/src/figni-viewer.js
@@ -224,10 +224,13 @@ export default class FigniViewerElement extends HTMLElement {
       this.#hotspots.push(this.base.appendChild(hotspot))
     })
     await this.base.updateComplete
+    this.#hotspots = Array.from(new Set(this.#hotspots))
     this.#hotspots.forEach((hotspot) => {
-      this.#modifyHotspot(hotspot)
+      if (!hotspot.classList.contains('figni-viewer-hotspot')) {
+        this.#modifyHotspot(hotspot)
+      }
     })
-    this.addEventListener('load', () => {
+    this.addEventListener('model-visibility', () => {
       setTimeout(() => {
         this.#enableAllHotspots()
       }, 100)


### PR DESCRIPTION
# Description

connectedCallbackが連続で呼ばれる場合、updateCompleteをawaitして待つため処理が重複する可能性があった。
処理の適用が重複すると適切なevent呼び出しが行われないため修正。

## Change Log

### Fixed

* modifyHotspotの適用が重複してしまう問題を修正