### PR TITLE
fix: モデルタグの変更によるロードでロード画面が消えない

### DIFF
--- a/src/figni-viewer.js
+++ b/src/figni-viewer.js
@@ -240,7 +240,7 @@ export default class FigniViewerElement extends HTMLElement {
         this.#modifyHotspot(hotspot)
       }
     })
-    this.addEventListener('model-visibility', () => {
+    this.addEventListener('load', () => {
       setTimeout(() => {
         this.#enableAllHotspots()
       }, 100)
@@ -353,6 +353,7 @@ export default class FigniViewerElement extends HTMLElement {
   async #loadModel() {
     this.#hideErrorPanel()
     this.#hideLoadingPanel()
+    this.closeHelpPanel()
     this.#disableAllHotspots()
     try {
       this.#showLoadingPanel()
@@ -682,19 +683,22 @@ export default class FigniViewerElement extends HTMLElement {
    * ヘルプページを閉じる。
    */
   closeHelpPanel() {
-    this.#closeAllPanels()
-    this.resetCameraTargetAndOrbit()
-    this.#helpPanelBase.classList.add('figni-viewer-help-panel-hidden')
-    while (this.#helpPanelBase.firstChild) {
-      this.#helpPanelBase.firstChild.remove()
+    if (this.#helpPanelBase) {
+      this.#closeAllPanels()
+      this.resetCameraTargetAndOrbit()
+      this.#helpPanelBase.classList.add('figni-viewer-help-panel-hidden')
+      while (this.#helpPanelBase.firstChild) {
+        this.#helpPanelBase.firstChild.remove()
+      }
+      if (this.#openedHelpPages.length > 0) {
+        this.base.endMesureHelpPage(
+          this.#openedHelpPages[this.#openedHelpPages.length - 1].name
+        )
+      }
+      this.#openedHelpPages = []
+      this.#helpButton &&
+        (this.#helpButton.innerHTML = `${SVG_HELP_ICON}<span>使い方</span>`)
     }
-    if (this.#openedHelpPages.length > 0) {
-      this.base.endMesureHelpPage(
-        this.#openedHelpPages[this.#openedHelpPages.length - 1].name
-      )
-    }
-    this.#openedHelpPages = []
-    this.#helpButton.innerHTML = `${SVG_HELP_ICON}<span>使い方</span>`
   }
 
   /**
@@ -1394,7 +1398,7 @@ export default class FigniViewerElement extends HTMLElement {
           `${Math.ceil(p * 100)}%`
         )
       })
-      this.addEventListener('model-visibility', () => {
+      this.addEventListener('load', () => {
         this.#hideLoadingPanel()
         this.openTipsPanel(TIPS.AR)
       })


### PR DESCRIPTION
# Description

- loadModel関数呼び出し時に表示するロード画面が初回以外の呼び出しで消えない問題を修正しました。
- これに伴いロード完了の合図を`model-visibility`イベントから`load`イベントに変更しました。

### Fixed

- モデルタグの変更によるロードでロード画面が消えない問題を修正
