### PR TITLE
feat: カスタムデータをログサーバーに送る機能を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - 自由なカメラ移動をサポートする属性`enable-pan`を追加
+- カスタムデータをログサーバーに送る関数`updateCustomData`を追加
 
 ### Changed
 

--- a/index.html
+++ b/index.html
@@ -146,6 +146,7 @@
       <button onclick="errorModelTag()">errorModelTag</button>
       <input type="text" id="modelTag" value="" />
       <button onclick="modelTagChange()">modelTagChange</button>
+      <button onclick="testCustomData()">testCustomData</button>
     </div>
     <script defer>
       let i = 0
@@ -166,6 +167,20 @@
       function modelTagChange() {
         const modelTag = document.getElementById('modelTag').value
         viewer.modelTag = modelTag
+      }
+      function testCustomData() {
+        viewer.updateCustomData('string', 'string', 'set')
+        viewer.updateCustomData('string', 'string', 'add')
+        viewer.updateCustomData('string', 'string', 'sub')
+        viewer.updateCustomData('test', 'string', 'add')
+        viewer.updateCustomData('test', 'string', 'delete')
+        viewer.updateCustomData('number', 0, 'add')
+        viewer.updateCustomData('number', 10, 'sub')
+        viewer.updateCustomData('array', ['a', 'b', 'c'], 'add')
+        viewer.updateCustomData('array', [], 'sub')
+        viewer.updateCustomData('object', { o: 'o' }, 'set')
+        viewer.updateCustomData('object', '', 'delete')
+        viewer.updateCustomData('dekete', '', 'delete')
       }
     </script>
     <style>

--- a/src/figni-viewer-base.js
+++ b/src/figni-viewer-base.js
@@ -19,6 +19,7 @@ export default class FigniViewerBaseElement extends ModelViewerElement {
   #helpPageViewCount = {}
   #abtest = {}
   #events = {}
+  #customData = {}
 
   async connectedCallback() {
     super.connectedCallback()
@@ -326,7 +327,7 @@ export default class FigniViewerBaseElement extends ModelViewerElement {
     }
   }
 
-  async #initializeWebSocket(itemId, token, tag = [], isStaging = false) {
+  async #initializeWebSocket(itemId, token, tags = [], isStaging = false) {
     if (this.#websocket) {
       this.#websocket.close()
     }
@@ -410,7 +411,7 @@ export default class FigniViewerBaseElement extends ModelViewerElement {
           this.#websocket.send(
             JSON.stringify({
               item_id: itemId,
-              tag: tag,
+              tag: tags,
               client_token: token,
               client_version: VERSION,
               stay_time: this.#stayTime,
@@ -431,6 +432,7 @@ export default class FigniViewerBaseElement extends ModelViewerElement {
               abtest: this.#abtest,
               help_page_view: this.#helpPageViewCount,
               panel_view: this.#panelViewCount,
+              custom_data: this.#customData,
             })
           )
         } else {

--- a/src/figni-viewer-base.js
+++ b/src/figni-viewer-base.js
@@ -406,12 +406,13 @@ export default class FigniViewerBaseElement extends ModelViewerElement {
         endMesure('interaction-time')
       })
 
+      this.#customData.tags = tags
+
       const sender = setInterval(() => {
         if (this.#websocket.readyState === WebSocket.OPEN) {
           this.#websocket.send(
             JSON.stringify({
               item_id: itemId,
-              tag: tags,
               client_token: token,
               client_version: VERSION,
               stay_time: this.#stayTime,

--- a/src/figni-viewer-base.js
+++ b/src/figni-viewer-base.js
@@ -224,6 +224,53 @@ export default class FigniViewerBaseElement extends ModelViewerElement {
   }
 
   /**
+   * WebSocketでサーバーに送信するデータを変更または追加する
+   * @param {string} key キー
+   * @param {any} value 値
+   * @param {"set"|"add"|"sub"|"delete"} action 操作
+   */
+  updateCustomData(key, value, action) {
+    try {
+      switch (action) {
+        case 'set': {
+          this.#customData[key] = value
+          break
+        }
+        case 'add': {
+          if (key in this.#customData) {
+            if (['number', 'string'].includes(typeof this.#customData[key])) {
+              this.#customData[key] += value
+            } else if (Array.isArray(this.#customData[key])) {
+              this.#customData[key].push(value)
+            } else {
+              this.#customData[key] = value
+            }
+          } else {
+            this.#customData[key] = value
+          }
+          break
+        }
+        case 'sub': {
+          if (key in this.#customData) {
+            if (['number'].includes(typeof this.#customData[key])) {
+              this.#customData[key] -= value
+            } else if (Array.isArray(this.#customData[key])) {
+              this.#customData[key].pop()
+            }
+          }
+          break
+        }
+        case 'delete': {
+          delete this.#customData[key]
+          break
+        }
+      }
+    } catch (e) {
+      throw new Error(`Failed to update custom data: ${e.message}`)
+    }
+  }
+
+  /**
    * ABテストの結果を設定する
    * @param {string} testName テストの名前
    * @param {string|number} result 結果

--- a/src/figni-viewer.js
+++ b/src/figni-viewer.js
@@ -2002,4 +2002,18 @@ export default class FigniViewerElement extends HTMLElement {
       this.#tempHidedHotspot = null
     }
   }
+
+  /**
+   * WebSocketでサーバーに送信するデータを変更または追加する
+   * @param {string} key キー
+   * @param {any} value 値
+   * @param {"set"|"add"|"sub"|"delete"} action 操作
+   */
+  updateCustomData(key, value, action) {
+    try {
+      this.base.updateCustomData(key, value, action)
+    } catch (e) {
+      console.error(e)
+    }
+  }
 }


### PR DESCRIPTION
# Description

カスタムデータをログサーバーに送信する`updateCustomData()`関数を追加しました。
これにより通常のFigni Viewer以外でとれた情報もログに残すことができます。

## Change Log

### Added

- カスタムデータをログサーバーに送る関数`updateCustomData()`を追加
