### PR TITLE
feat: 3DモデルのURLを取得する関数を分離

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- `item-id`と`token`から 3D モデルの URL を取得できる関数を追加しました。
+
 ### Changed
 
 ### Deprecated

--- a/src/figni-viewer.js
+++ b/src/figni-viewer.js
@@ -170,7 +170,7 @@ export default class FigniViewerElement extends HTMLElement {
   constructor() {
     super()
 
-    this.addEventListener('camera-change', (e) => {
+    this.addEventListener('camera-change', () => {
       if (this.#tempHidedHotspot) {
         if (!this.#clickableHotspot(this.#tempHidedHotspot.target)) {
           this.#showInitCameraButton()
@@ -847,7 +847,7 @@ export default class FigniViewerElement extends HTMLElement {
         delete this.#interactionCursors[e.pointerId]
       }
     })
-    window.addEventListener('scroll', (e) => {
+    window.addEventListener('scroll', () => {
       Object.keys(this.#interactionCursors).forEach((key) => {
         this.#deleteCursor(this.#interactionCursors[key])
         delete this.#interactionCursors[key]
@@ -1193,10 +1193,10 @@ export default class FigniViewerElement extends HTMLElement {
     panel.classWatcher = new ClassWatcher(
       panel,
       'figni-viewer-panel-hide',
-      (p) => {
+      () => {
         this.base.endMesurePanel(name)
       },
-      (p) => {
+      () => {
         this.base.startMesurePanel(name)
       }
     )


### PR DESCRIPTION
# Description

`item-id`、`token`および`mode-tag`から 3D モデルの URL を取得できる関数を追加しました。
既存の3Dモデル読み込み関数も今回作成した関数を利用するように変更しました。

## Change Log

### Added

- `item-id`と`token`から 3D モデルの URL を取得できる関数を追加しました。
